### PR TITLE
Fix Tests for 2020

### DIFF
--- a/test/integration/workarea/storefront/checkout_side_effects_integration_test.decorator
+++ b/test/integration/workarea/storefront/checkout_side_effects_integration_test.decorator
@@ -30,7 +30,7 @@ module Workarea
       assert_equal('XXXX-XXXX-XXXX-1', credit_card.display_number)
       assert_equal('1-1', credit_card.partial_number)
       assert_equal(1, credit_card.month)
-      assert_equal(2020, credit_card.year)
+      assert_equal(next_year, credit_card.year)
       refute(credit_card.token.blank?)
 
       complete_checkout('bcrouse@workarea.com', 'w3bl1nc')

--- a/test/models/workarea/payment/payware_credit_card_test.rb
+++ b/test/models/workarea/payment/payware_credit_card_test.rb
@@ -15,7 +15,7 @@ module Workarea
             postal_code: "19106"
           }
         )
-        payment.set_credit_card(number: "4111111111111111", month: "01", year: "2020", cvv: 111)
+        payment.set_credit_card(number: "4111111111111111", month: "01", year: next_year.to_s, cvv: 111)
         assert payment.credit_card.partial_number.present?
       end
 


### PR DESCRIPTION
Update all tests so that they no longer depend on the year 2020 as an
expiration year. Instead, use the  method provided by Workarea.

PAYWARE-1